### PR TITLE
Update _tantares_lv_engine_rd_58_s0_1.cfg

### DIFF
--- a/GameData/TantaresLV/parts/ANY_ENGINE/RD_58_V2/_tantares_lv_engine_rd_58_s0_1.cfg
+++ b/GameData/TantaresLV/parts/ANY_ENGINE/RD_58_V2/_tantares_lv_engine_rd_58_s0_1.cfg
@@ -75,7 +75,7 @@ PART
         atmosphereCurve
         {
             key = 0 353
-            key = 1 317
+            key = 1 117
         }
     }
 


### PR DESCRIPTION
Fix sea-level isp for RD-58. Sea level ISP get from another version of this engine.