### PR TITLE
Fix craft files for game versions 1.12 to 1.12.4

### DIFF
--- a/Crafts/[Blok-D].craft
+++ b/Crafts/[Blok-D].craft
@@ -1,5 +1,5 @@
 ship = [Blok-D]
-version = 1.12.5
+version = 1.12.0
 description = 
 type = VAB
 size = 2.50004148,3.76250076,2.50004196

--- a/Crafts/[Proton] Proton Example.craft
+++ b/Crafts/[Proton] Proton Example.craft
@@ -1,5 +1,5 @@
 ship = [Proton]
-version = 1.12.5
+version = 1.12.0
 description = 
 type = VAB
 size = 4.28128004,28.3380318,4.50000429

--- a/Crafts/[Tsyklon] R-36.craft
+++ b/Crafts/[Tsyklon] R-36.craft
@@ -1,5 +1,5 @@
 ship = [Tsyklon] R-36
-version = 1.12.3
+version = 1.12.0
 description = 
 type = VAB
 size = 2.00116777,21.0369453,2.17336321


### PR DESCRIPTION
Makes the craft files loadable for all 1.12.X versions, instead of only 1.12.5 and later.